### PR TITLE
プロフィールと個人開発一覧を更新

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "profile"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Commands
+
+### Development
+- `npm run dev` - Start the Next.js development server (http://localhost:3000)
+- `npm run build` - Build the production application
+- `npm start` - Start the production server
+
+### Code Quality
+- `npm run lint` - Run Biome linter with auto-fix on ./src
+- `npm run format` - Format code with Biome on ./src
+- `npm run check` - Run both lint and format with Biome on ./src
+- `npm run type-check` - Run TypeScript type checking (no emit)
+
+### Git Hooks
+- Pre-commit hooks are configured via Husky to run `npm run check` on staged files
+- This ensures code quality before commits
+
+## Architecture Overview
+
+This is a personal portfolio website built with Next.js 15 App Router and Chakra UI v3. The application follows a component-based architecture with clear separation of concerns.
+
+### Key Technologies
+- **Next.js 15.4.10** with App Router for server-side rendering and routing
+- **Chakra UI v3** for component styling with a custom dark theme
+- **React 19.1.0** for UI components
+- **TypeScript** for type safety across the codebase
+- **Biome** for linting and formatting (replaces ESLint/Prettier)
+- **React Context** for language switching (EN/JA)
+
+### Project Structure
+
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── layout.tsx         # Root layout with providers
+│   └── page.tsx           # Main page (client component)
+├── components/
+│   ├── providers.tsx      # Chakra & Language providers
+│   ├── tab/              # Tab content components
+│   │   ├── Main.tsx      # Profile & projects
+│   │   ├── Skills.tsx    # Skills showcase
+│   │   └── Support.tsx   # Payment/support options
+└── lib/
+    ├── consts.ts         # Project data, links, social media
+    ├── dictionary.ts     # i18n translations (EN/JA)
+    ├── theme.ts          # Chakra UI theme config
+    └── types.ts          # TypeScript interfaces
+```
+
+### Important Patterns
+
+1. **Client Components**: All interactive components use the 'use client' directive
+2. **Internationalization**: Simple dictionary-based i18n without external libraries
+3. **Styling**: Chakra UI with custom theme, gradients using bgGradient/bgClip
+4. **Data Management**: All constants and project data centralized in lib/consts.ts
+5. **Type Safety**: Comprehensive TypeScript types in lib/types.ts
+
+### Development Notes
+
+- Biome is configured to ignore generated Chakra UI helpers under `src/components/ui/` and `ChakraExtension.tsx`
+- The app uses 'SF Pro JP' font for Japanese text support
+- No test framework is currently configured
+- Profile images can be dynamically selected via URL parameters
+
+### Code Style
+- 4 spaces for indentation
+- Single quotes for JavaScript/TypeScript strings
+- Line width limit of 80 characters
+- Biome handles all formatting - always run `npm run check` before committing

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -119,24 +119,6 @@ export default function ProfileCard() {
                             h={100}
                             w={100}
                         />
-                        <Box h={100} w={100} mt={4} mb={4}>
-                            <HStack mb={1}>
-                                <Text fontSize="xl" color="whiteAlpha.900">
-                                    MBTI:
-                                </Text>
-                                <Text fontSize="xl" color="#88619a">
-                                    ENTP
-                                </Text>
-                            </HStack>
-                            <Image
-                                src="images/entp.webp"
-                                alt="ENTP Personality Type"
-                                h="80px"
-                                w="80px"
-                                borderRadius="sm"
-                                objectFit="cover"
-                            />
-                        </Box>
                     </Stack>
                 </Stack>
             </Box>

--- a/src/components/tab/Main.tsx
+++ b/src/components/tab/Main.tsx
@@ -288,21 +288,23 @@ export default function Main() {
                                     {project.externalLinkText}
                                 </ExLink>
                             </HStack>
-                            <HStack pl={{ base: 0, md: 2 }}>
-                                <Box color="white">
-                                    <FaGithub />
-                                </Box>
-                                <ExLink
-                                    href={project.githubLink}
-                                    bgGradient="to-r"
-                                    gradientFrom="#fff"
-                                    gradientTo="#adadad"
-                                    bgClip="text"
-                                    color="transparent"
-                                >
-                                    {project.githubRepoName}
-                                </ExLink>
-                            </HStack>
+                            {project.githubLink && project.githubRepoName && (
+                                <HStack pl={{ base: 0, md: 2 }}>
+                                    <Box color="white">
+                                        <FaGithub />
+                                    </Box>
+                                    <ExLink
+                                        href={project.githubLink}
+                                        bgGradient="to-r"
+                                        gradientFrom="#fff"
+                                        gradientTo="#adadad"
+                                        bgClip="text"
+                                        color="transparent"
+                                    >
+                                        {project.githubRepoName}
+                                    </ExLink>
+                                </HStack>
+                            )}
                         </Stack>
                         <Wrap pt={2}>
                             {project.techStacks.map((techStack) => (

--- a/src/components/tab/Main.tsx
+++ b/src/components/tab/Main.tsx
@@ -4,13 +4,11 @@ import {
     Grid,
     Heading,
     HStack,
-    Link,
     Stack,
     Text,
     Wrap,
     WrapItem,
 } from '@chakra-ui/react';
-import Image from 'next/image';
 import { useContext } from 'react';
 import { BiLinkExternal } from 'react-icons/bi';
 import { FaGithub } from 'react-icons/fa';
@@ -105,6 +103,10 @@ const projects: ProjectProps[] = [
         ],
     },
     {
+        ...projectsElement.nashForge,
+        techStacks: [techStack.ts, techStack.nextjs, techStack.vercel],
+    },
+    {
         ...projectsElement.scribbles,
         techStacks: [
             techStack.ts,
@@ -112,25 +114,6 @@ const projects: ProjectProps[] = [
             techStack.python,
             techStack.chakra,
             techStack.chromeExtension,
-        ],
-    },
-    {
-        ...projectsElement.emailForge,
-        techStacks: [
-            techStack.ts,
-            techStack.nextjs,
-            techStack.chakra,
-            techStack.vercel,
-        ],
-    },
-    {
-        ...projectsElement.gpProofreader,
-        techStacks: [
-            techStack.ts,
-            techStack.nextjs,
-            techStack.chakra,
-            techStack.langChain,
-            techStack.vercel,
         ],
     },
     {
@@ -341,22 +324,6 @@ export default function Main() {
                                     </HStack>
                                 </WrapItem>
                             ))}
-                            {projects[i].githubRepoName === 'EmailForge' && (
-                                <Box pl={{ base: 0, md: 2 }}>
-                                    <Link
-                                        href="https://openai.com/"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        <Image
-                                            src="/images/OpenAI.jpg"
-                                            alt="OpenAI"
-                                            width={130}
-                                            height={130}
-                                        />
-                                    </Link>
-                                </Box>
-                            )}
                         </Wrap>
                     </TabContainer>
                 ))}

--- a/src/components/tab/Skills.tsx
+++ b/src/components/tab/Skills.tsx
@@ -3,9 +3,7 @@ import {
     AWSIcon,
     DynamoDBIcon,
     GCPIcon,
-    JavaScriptIcon,
     MySQLIcon,
-    NextJsIcon,
     PythonIcon,
     TabContainer,
     TypeScriptIcon,
@@ -25,16 +23,6 @@ const techStack: TechStack = {
             name: 'TypeScript',
             icon: <TypeScriptIcon />,
             link: serviceLink.ts,
-        },
-        {
-            name: 'JavaScript',
-            icon: <JavaScriptIcon />,
-            link: serviceLink.js,
-        },
-        {
-            name: 'Next.js',
-            icon: <NextJsIcon />,
-            link: serviceLink.nextjs,
         },
     ],
     databases: [

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -47,8 +47,6 @@ export const projectsElement: ProjectsElementProps = {
     nashForge: {
         link: 'https://poker.k0ta.dev/' as const,
         externalLinkText: 'NashForge' as const,
-        githubLink: 'https://github.com/07130918/NashForge' as const,
-        githubRepoName: 'NashForge' as const,
     } as const,
     scribbles: {
         link: 'https://chrome.google.com/webstore/detail/scribbles/kjbdhcdgdcipnifdhnpldjibglpjnjib?hl=ja&authuser=0' as const,

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -44,18 +44,11 @@ export const projectsElement: ProjectsElementProps = {
         githubLink: 'https://github.com/07130918/word-pop-quiz' as const,
         githubRepoName: 'word-pop-quiz' as const,
     } as const,
-    emailForge: {
-        link: 'https://everybody-can-make-emails-easily.vercel.app/' as const,
-        externalLinkText: 'EMail Forge' as const,
-        githubLink: 'https://github.com/07130918/EmailForge' as const,
-        githubRepoName: 'EmailForge' as const,
-    } as const,
-    gpProofreader: {
-        link: 'https://gp-proofreader.vercel.app/' as const,
-        externalLinkText: 'GP-proofreader' as const,
-        githubLink:
-            'https://github.com/07130918/LLM-Playground/tree/main/proofread-web-app' as const,
-        githubRepoName: 'LLM-Playground' as const,
+    nashForge: {
+        link: 'https://poker.k0ta.dev/' as const,
+        externalLinkText: 'NashForge' as const,
+        githubLink: 'https://github.com/07130918/NashForge' as const,
+        githubRepoName: 'NashForge' as const,
     } as const,
     scribbles: {
         link: 'https://chrome.google.com/webstore/detail/scribbles/kjbdhcdgdcipnifdhnpldjibglpjnjib?hl=ja&authuser=0' as const,

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -7,7 +7,7 @@ export const text = {
                 and: 'and ',
                 inc2: 'AICE Inc.',
                 addition:
-                    ', building learning-support web applications used by thousands of people.',
+                    ', building web applications and APIs used by thousands of people.',
             },
             current:
                 'I enjoy turning rough ideas into products people can actually use. At work and in side projects, I focus on shaping ambiguous problems into simple interfaces and reliable systems.',
@@ -33,7 +33,7 @@ export const text = {
                 and: 'と',
                 inc2: 'AICE株式会社',
                 addition:
-                    'で、数千人が使う学習支援Webアプリケーションを開発しています。',
+                    'で、数千人が使うWebアプリケーション, APIを開発しています。',
             },
             current:
                 'ゼロから何かを作り上げるのが好きです。仕事でも個人開発でも、まだ曖昧な課題を整理し、使う人に届くシンプルなUIと信頼できる仕組みに落とし込むことを大切にしています。',

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -7,14 +7,14 @@ export const text = {
                 and: 'and ',
                 inc2: 'AICE Inc.',
                 addition:
-                    ', building web applications used by thousands of people.',
+                    ', building learning-support web applications used by thousands of people.',
             },
             current:
-                "I'm passionate about building things from scratch! From lecture management systems to student review platforms, I've created web apps that make people's lives easier. In my personal projects, I also develop Chrome extensions. I love taking complex problems and turning them into simple, elegant solutions using TypeScript and Python.",
+                'I enjoy turning rough ideas into products people can actually use. At work and in side projects, I focus on shaping ambiguous problems into simple interfaces and reliable systems.',
             travel: 'I love traveling!',
-            into: "Recently, I've been really into learning English and playing poker.",
+            into: "Recently, I've been diving deeper into English and poker. My main side project is NashForge, a poker strategy web app where I explore product design, game logic, and practical tooling for players.",
             mindset:
-                "I'm endlessly curious and always building something. Whether it's exploring a new tech stack or working on a fun side project, I believe the best way to learn is by rolling up your sleeves and creating something awesome!",
+                "I'm curious, hands-on, and happiest when I'm learning by building. Whether it's a new technical challenge or a small product idea, I like moving from prototype to something polished enough to share.",
             job_contact:
                 'For business inquiries, feel free to reach out via X (Twitter) DM or email below!',
         },
@@ -33,14 +33,14 @@ export const text = {
                 and: 'と',
                 inc2: 'AICE株式会社',
                 addition:
-                    'で、数千人が使うWebアプリケーションを開発しています。',
+                    'で、数千人が使う学習支援Webアプリケーションを開発しています。',
             },
             current:
-                'ゼロから何かを作り上げるのが大好きです! 講師管理システムから学生向けレビューサイトまで、人々の生活を便利にするWebアプリを作ってきました。個人開発では、Chrome拡張機能なども作っています。TypeScriptやPythonを使って複雑な問題をシンプルで美しいソリューションに変えるのが得意です。',
+                'ゼロから何かを作り上げるのが好きです。仕事でも個人開発でも、まだ曖昧な課題を整理し、使う人に届くシンプルなUIと信頼できる仕組みに落とし込むことを大切にしています。',
             travel: '旅行が大好きです!',
-            into: '最近は英語とポーカーにハマっています。',
+            into: '最近は英語とポーカーにハマっています。個人開発ではNashForgeを中心に、ポーカー戦略を扱うWebアプリとして、プロダクト設計・ゲームロジック・プレイヤー向けツール作りを試しています。',
             mindset:
-                '好奇心旺盛で、常に何かを作り続けています。新しい技術スタックでも面白いサイドプロジェクトでも、手を動かしてものを作るのが一番の学習方法だと思っています！',
+                '好奇心旺盛で、手を動かしながら学ぶのが好きです。新しい技術でも小さなプロダクト案でも、まず試作し、公開できる品質まで磨き込む過程を楽しんでいます。',
             job_contact:
                 'お仕事依頼はX(Twitter)のDMか以下のメールアドレスまでお願いします!',
         },

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -20,9 +20,8 @@ export const text = {
         },
         deployments: [
             { title: 'English Vocabulary Quiz Web App' },
+            { title: 'Poker Strategy Web App' },
             { title: 'Notepad Chrome Extension' },
-            { title: 'Email Body Generator Web App' },
-            { title: 'English Proofreading Web App' },
             { title: 'To-Do List Chrome Extension' },
         ],
     },
@@ -47,9 +46,8 @@ export const text = {
         },
         deployments: [
             { title: '英単語クイズwebアプリ' },
+            { title: 'ポーカー戦略webアプリ' },
             { title: 'メモ帳Chrome拡張機能' },
-            { title: 'Eメール本文生成webアプリ' },
-            { title: '英文校正webアプリ' },
             { title: 'To-DoリストChrome拡張機能' },
         ],
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,8 +15,8 @@ export type TechStack = {
 export type ProjectElementProps = {
     link: string;
     externalLinkText: string;
-    githubLink: string;
-    githubRepoName: string;
+    githubLink?: string;
+    githubRepoName?: string;
 };
 
 export type ProjectsElementProps = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,8 +21,7 @@ export type ProjectElementProps = {
 
 export type ProjectsElementProps = {
     wordPopQuiz: ProjectElementProps;
-    emailForge: ProjectElementProps;
-    gpProofreader: ProjectElementProps;
+    nashForge: ProjectElementProps;
     scribbles: ProjectElementProps;
     toDoList: ProjectElementProps;
 };


### PR DESCRIPTION
## 概要
プロフィール本文と My personal projects / Career 表示を更新し、Codex / Serena 用のリポジトリ設定を追加しました。

## 変更内容
- 表示名を Kota Sato から Kota Ikeda に変更
- My personal projects から Eメール本文生成webアプリと英文校正webアプリを削除
- NashForge のカードを追加し、プライベートリポジトリのため GitHub リンクは非表示に変更
- プロフィール本文を日本語/英語ともに、Webアプリケーション/API と NashForge を軸にした内容へ更新
- MBTI: ENTP と関連画像を削除
- Career タブの Programming Languages & Frameworks から JavaScript / Next.js を削除
- AGENTS.md を追加し、現行の開発コマンド・技術スタック・構成を記載
- Serena の共有設定として .serena/project.yml と .serena/.gitignore を追加

## 動作確認
- `npm run check`
- `npm run type-check`
- `npm run build`
- `npm run dev -- --port 3001` でローカル起動し、Playwright で以下を確認
  - Kota Ikeda が表示され、Kota Sato が残っていないこと
  - 画像 alt が Kota Ikeda に更新されていること
  - NashForge が表示されること
  - NashForge カードに GitHub リンクが表示されないこと
  - 削除対象の2プロジェクトが表示されないこと
  - MBTI / ENTP が表示されないこと
  - Career タブの Programming Languages & Frameworks に Python / TypeScript が表示され、JavaScript / Next.js が表示されないこと
  - 日本語/英語のプロフィール文に更新内容が反映されていること
  - コンソールエラーがないこと

補足: `npm run build` と開発サーバー起動時に複数 lockfile の警告が出ていますが、ビルドは成功しています。今回の変更では lockfile には触れていません。

## レビュー観点
- 表示名の変更漏れがないか
- プロフィール文の日英表現が意図したトーンになっているか
- NashForge のプロジェクト説明・技術タグが期待に合っているか
- 削除対象の表示が残っていないか
- AGENTS.md / Serena 設定をリポジトリに含める方針で問題ないか
