### PR TITLE
表示名をKota Ikedaに更新

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -31,7 +31,7 @@ export default function ProfileCard() {
                     >
                         <Image
                             src={`images/me/${imageNumber}.jpg`}
-                            alt="Kota Sato"
+                            alt="Kota Ikeda"
                             objectFit="cover"
                             borderRadius="full"
                             w="90px"
@@ -48,7 +48,7 @@ export default function ProfileCard() {
                             bgClip="text"
                             color="transparent"
                         >
-                            Kota Sato
+                            Kota Ikeda
                         </Text>
                         <Text fontSize="md" color="gray.500" mb={3}>
                             (he/him)
@@ -69,7 +69,7 @@ export default function ProfileCard() {
                     >
                         <Image
                             src={`images/me/${imageNumber}.jpg`}
-                            alt="Kota Sato"
+                            alt="Kota Ikeda"
                             objectFit="cover"
                             borderRadius="full"
                             boxSize="190px"
@@ -85,7 +85,7 @@ export default function ProfileCard() {
                             bgClip="text"
                             color="transparent"
                         >
-                            Kota Sato
+                            Kota Ikeda
                         </Text>
                         <Text fontSize="lg" color="gray.500" mb={3}>
                             (he/him)

--- a/src/components/tab/Main.tsx
+++ b/src/components/tab/Main.tsx
@@ -132,7 +132,7 @@ export default function Main() {
             <TabContainer bgClip="text" color="whiteAlpha.900">
                 <Heading fontSize="xl" mb={3} color="whiteAlpha.900">
                     <TypingAnimation
-                        text="Hi there! I'm Kota Sato, a software developer from Tokyo."
+                        text="Hi there! I'm Kota Ikeda, a software developer from Tokyo."
                         mistakes={[
                             {
                                 position: 'Hi there! '.length,


### PR DESCRIPTION
## 概要
プロフィール上の表示名を Kota Sato から Kota Ikeda に更新しました。

## 変更内容
- プロフィールカードの表示名を Kota Ikeda に変更
- プロフィール画像の alt を Kota Ikeda に変更
- トップの自己紹介文を Kota Ikeda に変更

## 動作確認
- `npm run check`
- `npm run type-check`
- `npm run build`
- `npm run dev -- --port 3001` でローカル起動し、Playwright で以下を確認
  - Kota Ikeda が表示されること
  - Kota Sato が表示されないこと
  - 画像 alt が Kota Ikeda に更新されていること
  - コンソールエラーがないこと

補足: `npm run build` 時に複数 lockfile の警告が出ていますが、ビルドは成功しています。今回の変更では lockfile には触れていません。

## レビュー観点
- 表示名の変更漏れがないか
